### PR TITLE
Add '-enter' flag to login to the running container

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [license]: /LICENSE
 
-`cf-plugin-local-push` is a [cloudfoundry/cli](https://github.com/cloudfoundry/cli) plugin. It allows you to push your cloudfoundry application to your local docker container with actual [buildpacks](http://docs.cloudfoundry.org/buildpacks/) :whale:. This plugin manipulates [DEA](https://docs.cloudfoundry.org/concepts/architecture/execution-agent.html) (where cf application is runnging) enviroment. So this can be used for setting up very light weight debug environment for application developers. And power of docker build cache, start up application is really *fast*.
+`cf-plugin-local-push` is a [cloudfoundry/cli](https://github.com/cloudfoundry/cli) plugin. It allows you to push your cloudfoundry application to your local docker container with actual [buildpacks](http://docs.cloudfoundry.org/buildpacks/) :whale:. This plugin manipulates [DEA](https://docs.cloudfoundry.org/concepts/architecture/execution-agent.html) (where cf application is runnging) enviroment. This can be used for setting up very light weight debug environment for application developers or running unit tests. And power of docker build cache, start up application is really *fast*.
 
 This plugin is still *PoC*, so please be careful to use this plugin.  
 
 ## Why?
 
-Why we need this? Because the application developers (at least, me) want to debug their cf app on local environment before `push`-ing to actual environment. Since it's faster and you don't need care about breaking the app or wasting resources (you may not be able to connect CF inside DC), it's important to have local development environment.
+Why we need this? Because the application developers (at least, me) want to debug their cf app on local environment before `push` to actual environment. Since it's faster and you don't need care about breaking the app or wasting resources (you may not have internet access when they need to run it), it's important to have local development environment.
 
 Cloudfoundry community provides [bosh-lite](https://github.com/cloudfoundry/bosh-lite) for local dev environment for BOSH using warden containers. But for me, it's too heavy and not for **user**. It's only for CF operators. 
 
@@ -49,6 +49,12 @@ $ cf local-push
 
 ```bash
 $ curl $(docker-machine ip):8080
+```
+
+While container is running, you can enter the container and can see what's happening there,
+
+```bash
+$ cf local-push -enter
 ```
 
 ## VS.

--- a/docker.go
+++ b/docker.go
@@ -8,12 +8,15 @@ import (
 
 type Docker struct {
 	OutStream io.Writer
+	InStream  io.Reader
 	Discard   bool
 }
 
 // docker runs docker command
 func (d *Docker) execute(args ...string) error {
 	cmd := exec.Command("docker", args...)
+
+	cmd.Stdin = d.InStream
 	cmd.Stderr = d.OutStream
 	cmd.Stdout = d.OutStream
 

--- a/plugin.go
+++ b/plugin.go
@@ -33,6 +33,9 @@ const (
 
 	// Dockerfile is file name of Dockerfile
 	Dockerfile = "Dockerfile"
+
+	// DockerUser to exec command to container
+	DockerUser = "vcap"
 )
 
 // dockerfileText is used for build docker image for target application.
@@ -84,9 +87,9 @@ func (p *LocalPush) Run(cliConn plugin.CliConnection, arg []string) {
 func (p *LocalPush) run(ctx *CLIContext, args []string) int {
 
 	var (
-		port  string
-		image string
-
+		port    string
+		image   string
+		enter   bool
 		version bool
 	)
 
@@ -102,6 +105,7 @@ func (p *LocalPush) run(ctx *CLIContext, args []string) int {
 	flags.StringVar(&image, "image", DefaultImageName, "")
 	flags.StringVar(&image, "i", DefaultImageName, "(Short)")
 
+	flags.BoolVar(&enter, "enter", false, "")
 	flags.BoolVar(&version, "version", false, "")
 	flags.BoolVar(&version, "v", false, "(Short)")
 
@@ -126,10 +130,38 @@ func (p *LocalPush) run(ctx *CLIContext, args []string) int {
 		Reader: p.InStream,
 	}
 
+	// Use same name as image
+	container := image
+
+	docker := &Docker{
+		OutStream: p.OutStream,
+		InStream:  p.InStream,
+		Discard:   false,
+	}
+
 	// Check docker is installed or not.
 	if _, err := exec.LookPath("docker"); err != nil {
 		fmt.Fprintf(p.OutStream, "docker command is not found in your $PATH. Install it before.\n")
 		return ExitCodeError
+	}
+
+	// Enter the container
+	if enter {
+		fmt.Fprintf(p.OutStream, "(cf-local-push) Enter container\n")
+		err := docker.execute("exec",
+			"--interactive",
+			"--tty",
+			"--user", DockerUser,
+			container,
+			"/bin/bash",
+		)
+
+		if err != nil {
+			fmt.Fprintf(p.OutStream, "Failed to enter the container %s: %s", container, err)
+			return ExitCodeError
+		}
+
+		return ExitCodeOK
 	}
 
 	// Check Dockerfile is exist or not.
@@ -177,11 +209,6 @@ func (p *LocalPush) run(ctx *CLIContext, args []string) int {
 
 	fmt.Fprintf(p.OutStream, "(cf-local-push) Start building docker image\n")
 
-	docker := &Docker{
-		OutStream: p.OutStream,
-		Discard:   false,
-	}
-
 	if err := docker.execute("build", "-t", image, "."); err != nil {
 		fmt.Fprintf(p.OutStream, "%s\n", err)
 		return ExitCodeError
@@ -196,9 +223,6 @@ func (p *LocalPush) run(ctx *CLIContext, args []string) int {
 	portMap := fmt.Sprintf("%s:%s", port, port)
 	portEnv := fmt.Sprintf("PORT=%s", port)
 	portEnvVcap := fmt.Sprintf("VCAP_APP_PORT=%s", port)
-
-	// Use same name as image
-	container := image
 
 	go func() {
 		Debugf("Run command: docker run -p %s -e %s -e %s--name %s %s",
@@ -263,13 +287,16 @@ Options:
 
   -port PORT      Port number to map to docker container. You can access
                   to application via this port. By default, '8080' is used.
-                  If you use, docker machine for running docker, you can
+                  If you use docker machine for running docker, you can
                   access application by 'curl $(docker-machine ip):PORT)'.
 
   -image NAME     Docker image name. By default, 'local-push' is used.
 
-  -version        Show version and quit.
+  -enter          Enter the container which starts by 'local-push'.
+                  You must use this option after exec 'local-push' and
+                  while running. You can regard this as 'ssh'.
 
+  -version        Show version and quit.          
 `
 	return text
 }


### PR DESCRIPTION
While container is running, you can attach to the container and see what's happening there.

``` bash
$ cf local-push -enter
(cf-local-push) Enter container
vcap@99bb96a6c103:/$ 
```
