### PR TITLE
Parse manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 *.test
 sample/Dockerfile
+.atomenv.json

--- a/plugin.go
+++ b/plugin.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 
 	"github.com/cloudfoundry/cli/plugin"
 	"github.com/tcnksm/go-input"
@@ -169,6 +170,7 @@ func (p *LocalPush) run(ctx *CLIContext, args []string) int {
 	}
 	manifestFile, err := os.Open("manifest.yml")
 	appPath,err := filepath.Abs(filepath.Dir(manifestFile.Name()))
+	Debugf("App content path: %s", appPath)
 
 
 	manifest := Manifest{}


### PR DESCRIPTION
Sets up later PR with logic that will extract env vars from the
manifest and set those on the Docker container during container create.
